### PR TITLE
Replace call to bind with second arrow function

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img height="80" width="80" alt="goat" src="https://d1j8pt39hxlh3d.cloudfront.net/development/emojione/4.0/833/14168.svg?1533081835" />
 
 Exception-free nested nullable attribute accessor.
-An alternative to [facebookincubator/idx](https://github.com/facebookincubator/idx) in 52 bytes.
+An alternative to [facebookincubator/idx](https://github.com/facebookincubator/idx) in 50 bytes.
 </div/>
 
 <hr />
@@ -11,7 +11,7 @@ An alternative to [facebookincubator/idx](https://github.com/facebookincubator/i
 ## Install
 Just copy/paste this function into your project:
 ``` javascript
-var mb=(...p)=>p.reduce.bind(p,(a,c)=>Object(a)[c])
+var mb=(...p)=>o=>p.reduce((a,c)=>Object(a)[c],o)
 ```
 Alternatively, you can download [mb.js](https://raw.githubusercontent.com/burakcan/mb/master/mb.js).
 
@@ -50,3 +50,4 @@ getHelloLength(obj2); // undefined
 - [Eser Ozvataf](https://github.com/eserozvataf)
 - [Cahit Gürgüc](https://github.com/aborjinik)
 - [Alper Tekinalp](https://github.com/alpert)
+- [Max Gerber](https://github.com/maxwellgerber)

--- a/mb.js
+++ b/mb.js
@@ -1,1 +1,1 @@
-var mb=(...p)=>p.reduce.bind(p,(a,c)=>Object(a)[c])
+var mb=(...p)=>o=>p.reduce((a,c)=>Object(a)[c],o)

--- a/test.js
+++ b/test.js
@@ -52,6 +52,7 @@ const test = (condition, data) => {
 
 console.group('mb tests');
 test(mb('a')(data) === 1, 'a');
+test(mb('a', 'bad key', 'bad key', 'bad key')(data) === undefined, 'bad key');
 test(mb('b')(data) === null, 'b');
 test(mb('c')(data) === undefined, 'c');
 test(mb('d')(data)._ === 'object', 'd');

--- a/test.js
+++ b/test.js
@@ -61,6 +61,7 @@ test(typeof mb('d', 'g')(data) === 'function', 'g');
 test(mb('d', 'h')(data) === 3, 'h');
 test(mb('d', 'j')(data) === 1, 'j');
 test(mb('d', 'k')(data) === 'string', 'k');
+test(mb('d', 'k', 'length')(data) === 6, 'length');
 test(mb('l', 'm')(data).length === 3, 'm');
 test(mb('l', 'm', 0, 'n')(data) === 1, 'n');
 test(mb('l', 'm', 1, 'n')(data) === 2, 'n');


### PR DESCRIPTION
Shaves off another 2 😉 

I added another test for the `'length'` example from the README
Without this test, you can replace `Object(a)` with `{...a}` and lose another 3 characters, but then the example doesn't work.