### PR TITLE
Path as array, not vararg. New tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img height="80" width="80" alt="goat" src="https://d1j8pt39hxlh3d.cloudfront.net/development/emojione/4.0/833/14168.svg?1533081835" />
 
 Exception-free nested nullable attribute accessor.
-An alternative to [facebookincubator/idx](https://github.com/facebookincubator/idx) in 40 bytes.
+An alternative to [facebookincubator/idx](https://github.com/facebookincubator/idx) in 34 bytes.
 
 </div/>
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img height="80" width="80" alt="goat" src="https://d1j8pt39hxlh3d.cloudfront.net/development/emojione/4.0/833/14168.svg?1533081835" />
 
 Exception-free nested nullable attribute accessor.
-An alternative to [facebookincubator/idx](https://github.com/facebookincubator/idx) in 34 bytes.
+An alternative to [facebookincubator/idx](https://github.com/facebookincubator/idx) in 38 bytes.
 
 </div/>
 
@@ -13,7 +13,7 @@ An alternative to [facebookincubator/idx](https://github.com/facebookincubator/i
 
 Just copy/paste this function into your project:
 ``` javascript
-mb=p=>o=>p.map(c=>o=(o||{})[c])&&o
+var mb=p=>o=>p.map(c=>o=(o||{})[c])&&o
 ```
 
 Alternatively, you can download [mb.js](https://raw.githubusercontent.com/burakcan/mb/master/mb.js).
@@ -58,3 +58,4 @@ getHelloLength(obj2); // undefined
 - [Max Gerber](https://github.com/maxwellgerber)
 - [Cem Ekici](https://github.com/cekici)
 - [Atanas Minev](https://github.com/atmin)
+- [Peter Levi](https://github.com/peterlevi)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An alternative to [facebookincubator/idx](https://github.com/facebookincubator/i
 
 Just copy/paste this function into your project:
 ``` javascript
-var mb=(...p)=>o=>p.map(c=>o=o&&o[c])&&o
+mb=p=>o=>p.map(c=>o=(o||{})[c])&&o
 ```
 
 Alternatively, you can download [mb.js](https://raw.githubusercontent.com/burakcan/mb/master/mb.js).
@@ -21,8 +21,8 @@ Alternatively, you can download [mb.js](https://raw.githubusercontent.com/burakc
 ## Use
 
 ```javascript
-var getHello = mb("a", "b", 0, "hello");
-var getHelloLength = mb("a", "b", 0, "hello", "length");
+var getHello = mb(["a", "b", 0, "hello"]);
+var getHelloLength = mb(["a", "b", 0, "hello", "length"]);
 
 var obj1 = {
   a: {

--- a/mb.js
+++ b/mb.js
@@ -1,1 +1,1 @@
-var mb=(...p)=>o=>p.map(c=>o=o&&o[c])&&o
+mb=p=>o=>p.map(c=>o=(o||{})[c])&&o

--- a/mb.js
+++ b/mb.js
@@ -1,1 +1,1 @@
-mb=p=>o=>p.map(c=>o=(o||{})[c])&&o
+var mb=p=>o=>p.map(c=>o=(o||{})[c])&&o

--- a/test.js
+++ b/test.js
@@ -51,27 +51,30 @@ const test = (condition, data) => {
 }
 
 console.group('mb tests');
-test(mb('a')(data) === 1, 'a');
-test(mb('a', 'bad key', 'bad key', 'bad key')(data) === undefined, 'bad key');
-test(mb('b')(data) === null, 'b');
-test(mb('c')(data) === undefined, 'c');
-test(mb('d')(data)._ === 'object', 'd');
-test(JSON.stringify(mb('d', 'e')(data)) === '{}', 'e');
-test(mb('d', 'f')(data) === null, 'f');
-test(typeof mb('d', 'g')(data) === 'function', 'g');
-test(mb('d', 'h')(data) === 3, 'h');
-test(mb('d', 'j')(data) === 1, 'j');
-test(mb('d', 'k')(data) === 'string', 'k');
-test(mb('d', 'k', 'length')(data) === 6, 'length');
-test(mb('l', 'm')(data).length === 3, 'm');
-test(mb('l', 'm', 0, 'n')(data) === 1, 'n');
-test(mb('l', 'm', 1, 'n')(data) === 2, 'n');
-test(mb('l', 'm', 2, 'n')(data) === 3, 'n');
-test(mb('l', 'o', 'p', 'q')(data) === true, 'q');
-test(mb('l', 'o', 'p', 'r')(data) === false, 'r');
-test(mb('l', 'o', 'p', 's', 't')(data) === 1, 't');
-test(mb('l', 'o', 'p', 'u', 1, 1)(data) === 2, 'u');
-test(mb('l', 'o', 'p', 's', 'spaced keys')(data) === 'hey', 'spaced keys');
+test(mb(['a'])(data) === 1, 'a');
+test(mb(['a', 'bad key', 'bad key', 'bad key'])(data) === undefined, 'bad key');
+test(mb(['b'])(data) === null, 'b');
+test(mb(['c'])(data) === undefined, 'c');
+test(mb(['d'])(data)._ === 'object', 'd');
+test(JSON.stringify(mb(['d', 'e'])(data)) === '{}', 'e');
+test(mb(['d', 'f'])(data) === null, 'f');
+test(typeof mb(['d', 'g'])(data) === 'function', 'g');
+test(mb(['d', 'h'])(data) === 3, 'h');
+test(mb(['d', 'j'])(data) === 1, 'j');
+test(mb(['d', 'k'])(data) === 'string', 'k');
+test(mb(['d', 'k', 'length'])(data) === 6, 'length');
+test(mb(['l', 'm'])(data).length === 3, 'm');
+test(mb(['l', 'm', 0, 'n'])(data) === 1, 'n');
+test(mb(['l', 'm', 1, 'n'])(data) === 2, 'n');
+test(mb(['l', 'm', 2, 'n'])(data) === 3, 'n');
+test(mb(['l', 'o', 'p', 'q'])(data) === true, 'q');
+test(mb(['l', 'o', 'p', 'r'])(data) === false, 'r');
+test(mb(['l', 'o', 'p', 's', 't'])(data) === 1, 't');
+test(mb(['l', 'o', 'p', 'u', 1, 1])(data) === 2, 'u');
+test(mb(['l', 'o', 'p', 's', 'spaced keys'])(data) === 'hey', 'spaced keys');
+
+test(mb([0, 1])([[1,2]]) === 2, 'array');
+test(mb([0, 1])([0]) === undefined, 'missing intermediate');
 
 console.info(`Passed tests ${results.passed} out of ${results.total}.`);
 


### PR DESCRIPTION
Since we anyway don't keep the same interface as idx, we may as well go and use arrays for path, not varargs. One can argue this also makes it easier to use dynamically-generated paths.

Also fixes the bug, and adds tests to cover it.

And makes `mb` global, which is questionable. But I do like my utility methods global so I can use them easily in console.